### PR TITLE
fix extra heap allocations when detector is disabled

### DIFF
--- a/deadlock.go
+++ b/deadlock.go
@@ -71,18 +71,18 @@ func (m *Mutex) id() lockID {
 // Unless deadlock detection is disabled, logs potential deadlocks to Opts.LogBuf,
 // calling Opts.OnPotentialDeadlock on each occasion.
 func (m *Mutex) Lock() {
+	// shortcut for disabled deadlock detection to prevent extra copying of `m.mu.Lock` to the heap
+	if Opts.Disable {
+		m.mu.Lock()
+		return
+	}
+
 	counterMu.Lock()
 	if m.muId == 0 {
 		m.muId = currID
 		currID++
 	}
 	counterMu.Unlock()
-
-	// shortcut for disabled deadlock detection to prevent extra copying of `m.mu.Lock` to the heap
-	if Opts.Disable {
-		m.mu.Lock()
-		return
-	}
 
 	lockEnabled(m.mu.Lock, m, false)
 }
@@ -121,17 +121,17 @@ func (m *RWMutex) id() lockID {
 // Unless deadlock detection is disabled, logs potential deadlocks to Opts.LogBuf,
 // calling Opts.OnPotentialDeadlock on each occasion.
 func (m *RWMutex) Lock() {
+	if Opts.Disable {
+		m.mu.Lock()
+		return
+	}
+
 	counterMu.Lock()
 	if m.muId == 0 {
 		m.muId = currID
 		currID++
 	}
 	counterMu.Unlock()
-
-	if Opts.Disable {
-		m.mu.Lock()
-		return
-	}
 
 	lockEnabled(m.mu.Lock, m, false)
 }
@@ -154,17 +154,17 @@ func (m *RWMutex) Unlock() {
 // Unless deadlock detection is disabled, logs potential deadlocks to Opts.LogBuf,
 // calling Opts.OnPotentialDeadlock on each occasion.
 func (m *RWMutex) RLock() {
+	if Opts.Disable {
+		m.mu.RLock()
+		return
+	}
+
 	counterMu.Lock()
 	if m.muId == 0 {
 		m.muId = currID
 		currID++
 	}
 	counterMu.Unlock()
-
-	if Opts.Disable {
-		m.mu.RLock()
-		return
-	}
 
 	lockEnabled(m.mu.RLock, m, true)
 }


### PR DESCRIPTION
## Summary
I found deadlock detector has one allocation overhead per locker call b/c it passes `Lock()` method to the `lock` helper, and it escapes.

## Benchmark

Before:
```
go test ./ -run ^$ -bench BenchmarkRWMutexAlloc -benchmem -memprofile=mem.pprof
goos: darwin
goarch: arm64
pkg: github.com/algorand/go-deadlock
BenchmarkRWMutexAlloc-10    	32553236	        36.69 ns/op	      16 B/op	       1 allocs/op
PASS
ok  	github.com/algorand/go-deadlock	2.273s
```
After:
```
go test ./ -run ^$ -bench BenchmarkRWMutexAlloc -benchmem -memprofile=mem.pprof
goos: darwin
goarch: arm64
pkg: github.com/algorand/go-deadlock
BenchmarkRWMutexAlloc-10    	45803848	        26.02 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/algorand/go-deadlock	2.201s
```